### PR TITLE
Add better asteroid wrapping. Add more settings and balancing.

### DIFF
--- a/asteroid.js
+++ b/asteroid.js
@@ -146,6 +146,34 @@ var Asteroid = new Phaser.Class({
             }
         }
 
+        // Handle literal corner case
+        if (childrenCount == 2) {
+            childrenCount++;
+            var cornerX = x;
+            var cornerY = y;
+
+            if (x < 400) {
+                cornerX += 800;
+            } else {
+                cornerX -= 800;
+            }
+
+            if (y < 300) {
+                cornerY += 600;
+            } else {
+                cornerY -= 600;
+            }
+
+            if (this.childAsteroids.length < childrenCount) {
+                var newAsteroid = new Asteroid(object.scene, cornerX, cornerY, this.size);
+                newAsteroid.setIsChild(true);
+                this.childAsteroids.push(newAsteroid);
+                object.scene.asteroids.add(newAsteroid, true);
+            } else {
+                this.childAsteroids[childrenCount - 1].setPosition(cornerX, cornerY);
+            }
+        }
+
         // Remove any "excess" asteroids
         while (this.childAsteroids.length > childrenCount) {
             object.scene.asteroids.killAndHide(this.childAsteroids[this.childAsteroids.length - 1]);

--- a/asteroid.js
+++ b/asteroid.js
@@ -13,6 +13,7 @@ var Asteroid = new Phaser.Class({
         Phaser.GameObjects.Image.call(this, scene)
 
         this.setTexture('asteroid');
+        this.isChild = false;
 
         // Change the scale and speed of the asteroids to match the size of the asteroid.
         // Smaller asteroids vary more in speed and can move faster.
@@ -31,8 +32,7 @@ var Asteroid = new Phaser.Class({
                 break;
         }
 
-        // Randomize the rotation of the asteroid
-        this.setAngle(Math.random() * 360);
+        this.childAsteroids = [];
 
         // Randomly place the asteroid at the border of the screen
         // TODO: Replace hard-coded screen bounds
@@ -71,19 +71,93 @@ var Asteroid = new Phaser.Class({
         this.direction.normalize();
     },
 
-    move: function (delta) {
+    move: function (delta, object) {
+        if (this.isChild || !this.active)
+            return;
+
+        for (var i = 0; i < this.childAsteroids.length; i++) {
+            if (!this.childAsteroids[i].active) {
+                this.childAsteroids[i].setIsChild(false);
+                for (var j = 0; j < this.childAsteroids.length; j++) {
+                    if (i == j)
+                        continue;
+
+                    object.scene.asteroids.killAndHide(this.childAsteroids[j]);
+                    object.scene.asteroids.remove(this.childAsteroids[j], true, true);
+                }
+
+                object.scene.asteroids.killAndHide(this);
+                object.scene.asteroids.remove(this, true, true);
+                break;
+            }
+        }
+
         // Move the asteroid based on the time passed. Wrap around when reaching the screen edge.
         var x = Phaser.Math.Wrap(this.x + delta * this.speed * this.direction.x,
-            this.displayWidth / 2, 800 - this.displayWidth / 2);
+            0, 800);
         var y = Phaser.Math.Wrap(this.y + delta * this.speed * this.direction.y,
-            this.displayHeight / 2, 600 - this.displayHeight / 2);
+            0, 600);
         this.setPosition(x, y);
+
+        // Add "child asteroids" to this asteroid. To the player it just looks like one asteroid
+        // wrapping around the screen.
+        var childrenCount = 0;
+        if (x >= 0 && x < this.displayWidth / 2) {
+            childrenCount++;
+            if (this.childAsteroids.length < childrenCount) {
+                var newAsteroid = new Asteroid(object.scene, this.x + 800, this.y, this.size);
+                newAsteroid.setIsChild(true);
+                this.childAsteroids.push(newAsteroid);
+                object.scene.asteroids.add(newAsteroid, true);
+            } else {
+                this.childAsteroids[childrenCount - 1].setPosition(this.x + 800, this.y);
+            }
+        } else if (x < 800 && x > 800 - this.displayWidth / 2) {
+            childrenCount++;
+            if (this.childAsteroids.length < childrenCount) {
+                var newAsteroid = new Asteroid(object.scene, this.x - 800, this.y, this.size);
+                newAsteroid.setIsChild(true);
+                this.childAsteroids.push(newAsteroid);
+                object.scene.asteroids.add(newAsteroid, true);
+            } else {
+                this.childAsteroids[childrenCount - 1].setPosition(this.x - 800, this.y);
+            }
+        }
+
+        if (y >= 0 && y < this.displayHeight / 2) {
+            childrenCount++;
+            if (this.childAsteroids.length < childrenCount) {
+                var newAsteroid = new Asteroid(object.scene, this.x, this.y + 600, this.size);
+                newAsteroid.setIsChild(true);
+                this.childAsteroids.push(newAsteroid);
+                object.scene.asteroids.add(newAsteroid, true);
+            } else {
+                this.childAsteroids[childrenCount - 1].setPosition(this.x, this.y + 600);
+            }
+        } else if (y < 600 && y > 600 - this.displayHeight / 2) {
+            childrenCount++;
+            if (this.childAsteroids.length < childrenCount) {
+                var newAsteroid = new Asteroid(object.scene, this.x, this.y - 600, this.size);
+                newAsteroid.setIsChild(true);
+                this.childAsteroids.push(newAsteroid);
+                object.scene.asteroids.add(newAsteroid, true);
+            } else {
+                this.childAsteroids[childrenCount - 1].setPosition(this.x, this.y - 600);
+            }
+        }
+
+        // Remove any "excess" asteroids
+        while (this.childAsteroids.length > childrenCount) {
+            object.scene.asteroids.killAndHide(this.childAsteroids[this.childAsteroids.length - 1]);
+            object.scene.asteroids.remove(this.childAsteroids[this.childAsteroids.length - 1], true, true);
+            this.childAsteroids.pop();
+        }
     },
 
     demolish: function (object, asteroids) {
         // If the asteroid isn't the smallest size, create 2 new asteroids in its location
         if (this.size > sizes.SMALL) {
-            for (i = 0; i < 2; i++) {
+            for (i = 0; i < gameSettings.asteroidBreakNum; i++) {
                 asteroids.add(new Asteroid(object.scene, this.x, this.y, this.size - 1), true);
             }
         }
@@ -91,6 +165,11 @@ var Asteroid = new Phaser.Class({
         // Kill the current asteroid
         // TODO: Play death animation before hiding
         asteroids.killAndHide(this);
+        for (var j = 0; j < this.childAsteroids.length; j++) {
+            object.scene.asteroids.killAndHide(this.childAsteroids[j]);
+            object.scene.asteroids.remove(this.childAsteroids[j], true, true);
+        }
+
         switch (this.size) {
             case sizes.LARGE:
                 object.scene.score += 20;
@@ -107,5 +186,9 @@ var Asteroid = new Phaser.Class({
               default:
                 break;
         }
+    },
+
+    setIsChild: function (isChild) {
+        this.isChild = isChild;
     }
 });

--- a/game.js
+++ b/game.js
@@ -22,6 +22,10 @@ var gameSettings = {
   shootRecoil: 0.1,
   beamSpeed: 250,
   terminalVelocity: 0.2,
+  initialAsteroids: 1,
+  asteroidWaveIncrease: 1,
+  asteroidBreakNum: 2,
+  spawnDelay: 3000,
 }
 
 var game = new Phaser.Game(config);

--- a/gameScene.js
+++ b/gameScene.js
@@ -30,7 +30,7 @@ class GameScene extends Phaser.Scene {
     this.projectiles = this.add.group();
 
     //Asteroids
-    this.asteroidSpawnNum = 4; // The number of asteroids to spawn next wave, initially 4
+    this.asteroidSpawnNum = gameSettings.initialAsteroids; // The number of asteroids to spawn next wave, initial amount set here
     this.asteroids = this.physics.add.group({ classType: Asteroid, runChildUpdate: true }); // The group of asteroids
 
     //Collision Asteroid and Enemy
@@ -42,6 +42,8 @@ class GameScene extends Phaser.Scene {
     //SCORE
     this.scoreLabel = this.add.bitmapText(10, 5, "pixelFont", "SCORE 0", 16);
     this.score = 0;
+
+    this.waveResetTime = 0;
   }
 
   update(time, delta) {
@@ -67,23 +69,29 @@ class GameScene extends Phaser.Scene {
     }
 
     // Move all the asteroids
-    this.asteroids.getChildren().forEach(function (asteroid) {
-        asteroid.move(delta);
-    });
+    for (var i = 0; i < this.asteroids.getChildren().length; i++) {
+        this.asteroids.getChildren()[i].move(delta, { scene: this });
+    }
 
     // Begin the next wave if all asteroids are gone
     if (this.asteroids.countActive(true) == 0) {
+        if (this.waveResetTime > 0) {
+            this.waveResetTime -= delta;
+            return;
+        }
+
+        this.waveResetTime = gameSettings.spawnDelay;
+
         // Clear out inactive asteroids, remove them from the scene and destroy them
         this.asteroids.clear(true, true);
-        //index = 0;
 
         // Spawn new asteroids
         for (i = 0; i < this.asteroidSpawnNum; i++) {
             this.asteroids.add(new Asteroid(this, -1, -1, sizes.LARGE), true);
         }
 
-        // Make next wave spawn 2 more asteroids than this one (this is what it looked like Asteroids was doing)
-        this.asteroidSpawnNum += 2;
+        // Make next wave spawn more asteroids than this one
+        this.asteroidSpawnNum += gameSettings.asteroidWaveIncrease;
     }
   }
 


### PR DESCRIPTION
Make all of each asteroid visible at a given time without teleporting them. If an asteroid is halfway across a screen boundary, half can be seen on one edge of the screen while the other half can be seen on the opposite edge. I think this is the best way to incorporate wrapping without the asteroids surprising the player at the screen boundaries.

Also add in a wave start delay so the player can get back to the middle area (where asteroids don't spawn), like in Asteroids.